### PR TITLE
Fix boost::bind compilation with Boost 1.58

### DIFF
--- a/src/fmt-dat-got.cpp
+++ b/src/fmt-dat-got.cpp
@@ -180,7 +180,7 @@ Archive_DAT_GoT::Archive_DAT_GoT(stream::inout_sptr psArchive)
 		psArchive,
 		0,
 		GOT_MAX_FILES * GOT_FAT_ENTRY_LEN,
-		boost::bind<void>(&Archive_DAT_GoT::truncateFAT, this, _1)
+		boost::bind(&Archive_DAT_GoT::truncateFAT, this, _1)
 	);
 
 	filter_sptr fatCryptR(new filter_xor_crypt(0, 128));


### PR DESCRIPTION
For some reason, Boost 1.58 doesn't like boost::bind<type>() anymore.
boost::bind(), without explicitly stating the template specialization,
works, though, and has always worked with older Boost version as well.
